### PR TITLE
fix: invalid message type

### DIFF
--- a/jupyter-messages.el
+++ b/jupyter-messages.el
@@ -211,8 +211,9 @@ decoded string."
       (prog1 val
         (when-let* ((msg-type (and (listp val)
                                    (plist-get val :msg_type))))
-          (plist-put
-           val :msg_type (jupyter-message-type-as-keyword msg-type)))))))
+         (unless (string-empty-p msg-type))
+           (plist-put
+            val :msg_type (jupyter-message-type-as-keyword msg-type)))))))
 
 (defun jupyter-decode-time (str)
   "Decode an ISO 8601 time STR into a time object.


### PR DESCRIPTION
for [almond](https://almond.sh/), when execute code like:
```
var m = Map("A" -> 1)
m += ("B" -> 2)
```
a *Invalid mesage type* error received, and almond kernel will exit.