### PR TITLE
Require eieio for jupyter-channel defclass

### DIFF
--- a/jupyter-channel.el
+++ b/jupyter-channel.el
@@ -26,6 +26,8 @@
 
 ;;; Code:
 
+(require 'eieio)
+
 (defclass jupyter-channel ()
   ((type
     :type keyword


### PR DESCRIPTION
Recently I switched to the Emacs `native-comp` branch, and while the missing require apparently didn't really hurt before, after native compiling I got an error that it couldn't find variable jupyter-channel when loading jupyter.
This seems to fix it.