### PR TITLE
parse `DataFrame` from evaluating a Julia cell as an Org table

### DIFF
--- a/jupyter-julia.el
+++ b/jupyter-julia.el
@@ -248,35 +248,35 @@ TABLE-AS-HTML-STR is the jupyter html representation of a DataFrame, like
 Returns \(cons 'ok org-table-representing-dataframe\), nil otherwise."
   (when (not (null table-as-html-str))
     (when-let* ((e (with-temp-buffer
-                       (insert table-as-html-str)
-                       (libxml-parse-html-region (point-min) (point-max))))
-                  (headers-and-rows (pcase e
-                                      (`(html , _html-attribs
-                                                (body , _body-attribs
-                                                        (table ((class . "data-frame"))
-                                                               . ,rest)))
-                                       rest)))
-                  (first-tr (pcase (car headers-and-rows)
-                              (`(thead ,_attr . ,rest)
-                               (car rest))))
-                  (th-nodes (pcase first-tr
-                              (`(tr ,_attrib . ,ths)
-                               ths)))
-                  (col-names
-                   (mapcar
-                    'caddr
-                    (--drop-while
-                     (pcase it
-                       (`(th ,_attrib . ,col-name)
-                        (null col-name)))
-                     th-nodes)))
-                  (second-header-row
-                   (pcase (-first-item headers-and-rows)
-                     (`(thead ,_attr . ,rest)
-                      (cadr
-                       rest))))
-                  (col-types
-                   (mapcar 'caddr
+                     (insert table-as-html-str)
+                     (libxml-parse-html-region (point-min) (point-max))))
+                (headers-and-rows (pcase e
+                                    (`(html , _html-attribs
+                                              (body , _body-attribs
+                                                      (table ((class . "data-frame"))
+                                                             . ,rest)))
+                                     rest)))
+                (first-tr (pcase (car headers-and-rows)
+                            (`(thead ,_attr . ,rest)
+                             (car rest))))
+                (th-nodes (pcase first-tr
+                            (`(tr ,_attrib . ,ths)
+                             ths)))
+                (col-names
+                 (mapcar
+                  'caddr
+                  (--drop-while
+                   (pcase it
+                     (`(th ,_attrib . ,col-name)
+                      (null col-name)))
+                   th-nodes)))
+                (second-header-row
+                 (pcase (-first-item headers-and-rows)
+                   (`(thead ,_attr . ,rest)
+                    (cadr
+                     rest))))
+                (col-types
+                 (mapcar 'caddr
                          (--drop-while
                           (pcase it
                             (`(th ,_attrib . ,col-name)
@@ -284,25 +284,25 @@ Returns \(cons 'ok org-table-representing-dataframe\), nil otherwise."
                             (_
                              t))
                           second-header-row)))
-                  (data-rows
-                   (pcase (cadr headers-and-rows)
-                     (`(tbody ,_attrib (p ,_pattrib ,_table-name) . ,rest)
-                      rest)))
-                  (extracted-data
-                   (mapcar
-                    (pcase-lambda (`(tr ,_tr-attrib . ,rest))
-                      (let ((row-without-numbering
-                             (cdr rest)))
-                        (mapcar
-                         (pcase-lambda (`(td ,_td-attrib . ,value))
-                           (car value))
-                         row-without-numbering)))
-                    data-rows)))
-    (cons 'ok
-          (jupyter-org-scalar
-         (append
-          (list col-names)
-          extracted-data))))))
+                (data-rows
+                 (pcase (cadr headers-and-rows)
+                   (`(tbody ,_attrib (p ,_pattrib ,_table-name) . ,rest)
+                    rest)))
+                (extracted-data
+                 (mapcar
+                  (pcase-lambda (`(tr ,_tr-attrib . ,rest))
+                    (let ((row-without-numbering
+                           (cdr rest)))
+                      (mapcar
+                       (pcase-lambda (`(td ,_td-attrib . ,value))
+                         (car value))
+                       row-without-numbering)))
+                  data-rows)))
+      (cons 'ok
+            (jupyter-org-scalar
+             (append
+              (list col-names)
+              extracted-data))))))
 
 (cl-defmethod jupyter-org-result ((_mime (eql :text/html))
                                   &context (jupyter-lang julia)

--- a/jupyter-julia.el
+++ b/jupyter-julia.el
@@ -242,7 +242,7 @@ end")))
 (defun jupyter-julia--try-parse-dataframe (table-as-html-str)
   "Try to parse DataFrame to transform to org table.
 
-TABLE-AS-HTML-STR is the jupyter html representation of a DataFrame, like 
+TABLE-AS-HTML-STR is the jupyter html representation of a DataFrame, like
 <html>… <table class=data-frame>…
 
 Returns \(cons 'ok org-table-representing-dataframe\), nil otherwise."
@@ -301,7 +301,8 @@ Returns \(cons 'ok org-table-representing-dataframe\), nil otherwise."
       (cons 'ok
             (jupyter-org-scalar
              (append
-              (list col-names)
+              (list col-names
+                    'hline)
               extracted-data))))))
 
 (cl-defmethod jupyter-org-result ((_mime (eql :text/html))

--- a/jupyter-julia.el
+++ b/jupyter-julia.el
@@ -277,7 +277,7 @@ Returns \(cons 'ok org-table-representing-dataframe\), nil otherwise."
                        rest))))
                   (col-types
                    (mapcar 'caddr
-                         (--drop-while ;; TODO
+                         (--drop-while
                           (pcase it
                             (`(th ,_attrib . ,col-name)
                              (null col-name))


### PR DESCRIPTION
[Julia DataFrames](https://juliadata.github.io/DataFrames.jl/stable/) is a [famous package](https://juliaobserver.com/packages/DataFrames) in the Julia universe (think Python's pandas).

This will parse the html representation of a `DataFrame` after evaluating a cell. I tried to keep things maintainable, although recursing through html is always cumbersome.

I don't know where/if I should add a unit test for this. Is there a guide for this?

Also, I think I might've missed the way headers should be passed to `jupyter-org-scalar`. If passing headers is not part of this function, then I guess we're ok.