### PR TITLE
Don't add the font-lock-multiline property to finalized cell text

### DIFF
--- a/jupyter-repl.el
+++ b/jupyter-repl.el
@@ -739,9 +739,7 @@ Place `point' at `point-max'."
     ;; cell or after any continuation prompts.  See
     ;; `jupyter-repl-insert-prompt'.
     (remove-text-properties beg (point) '(rear-nonsticky))
-    ;; font-lock-multiline to avoid improper syntactic elements from
-    ;; spilling over to the rest of the buffer.
-    (add-text-properties beg (point) '(read-only t font-lock-multiline t))
+    (add-text-properties beg (point) '(read-only t))
     ;; reset the undo list so that a completed cell doesn't get undone.
     (setq buffer-undo-list '((t . 0)))))
 

--- a/jupyter-repl.el
+++ b/jupyter-repl.el
@@ -1807,11 +1807,6 @@ VERBOSE has the same meaning as in
         (forward-char)
         (skip-syntax-forward "^()\"")))))
 
-(defun jupyter-repl-font-lock-syntactic-face-function (face-fun state)
-  "Narrow to the input cell, use FACE-FUN to obtain the face given STATE."
-  (jupyter-with-repl-cell
-    (funcall face-fun state)))
-
 (cl-defgeneric jupyter-repl-initialize-fontification ()
   "Initialize fontification for the current REPL buffer."
   (let (fld frf sff spf comment)
@@ -1837,9 +1832,7 @@ VERBOSE has the same meaning as in
                      (cons 'font-lock-fontify-region-function
                            (apply-partially
                             #'jupyter-repl-font-lock-fontify-region frf))
-                     (cons 'font-lock-syntactic-face-function
-                           (apply-partially
-                            #'jupyter-repl-font-lock-syntactic-face-function sff)))))
+                     (cons 'font-lock-syntactic-face-function sff))))
       (setq-local comment-start comment)
       (setq font-lock-defaults
             (apply #'list kws kws-only case-fold syntax-alist vars)))


### PR DESCRIPTION
This is a fix for #219.

Looking further into the issue and with the help of the reproduction in https://github.com/nnicandro/emacs-jupyter/issues/219#issuecomment-641487092 it seems that property added to the cell text causes an infinite loop in the `font-lock-extend-region-functions` handling during fontification whenever the input is long.