### PR TITLE
Pandoc conversion delay and output order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ install:
   # /usr/local/share/jupyter. This installs one with an absolute path using our
   # python3
   - sudo python3.6 -m ipykernel.kernelspec
+  # Install additional packages needed by the tests
+  - sudo apt-get install pandoc
 before_script:
   # Ensure Jupyter runtime dir can be written to
   - mkdir -p $(jupyter --runtime-dir)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,8 @@ install:
   - if not exist C:\Miniconda3-x64\envs\jupyter conda create --name jupyter python=%JUPYTER_PYTHON_VERSION%
   - conda activate jupyter
   - conda install jupyter
+  # Install additional packages needed by tests
+  - conda install -c conda-forge pandoc
   # Ensure Jupyter runtime dir can be written to
   - ps: mkdir -p (jupyter --runtime-dir)
   - jupyter --version

--- a/test/jupyter-test.el
+++ b/test/jupyter-test.el
@@ -2929,6 +2929,51 @@ publish_display_data({'text/plain': \"foo\", 'text/latex': \"$\\alpha$\"});"
        (forward-line)
        (should (looking-at-p ": hello"))))))
 
+(ert-deftest org-babel-jupyter-pandoc-output-order ()
+  :tags '(org pandoc)
+  ;; See #351
+  (ert-info ("Ensure output order doesn't depend on Pandoc processing time")
+    (ert-info ("Async")
+      (jupyter-org-test-src-block
+       "\
+from IPython.display import HTML, Markdown, Latex
+
+print(1)
+display(HTML('<b>bold</b>'),
+        Latex('\\\\bf{lbold}'),
+        Markdown('**mbold**'))
+print(2)"
+       "\
+:RESULTS:
+: 1
+*bold*
+*lbold*
+*mbold*
+: 2
+:END:
+"
+       :async "yes"
+       :pandoc "t"))
+    (ert-info ("Sync")
+      (jupyter-org-test-src-block
+       "\
+from IPython.display import HTML, Markdown, Latex
+
+print(1)
+display(HTML('<b>bold</b>'),
+        Latex('\\\\bf{lbold}'),
+        Markdown('**mbold**'))
+print(2)"
+       "\
+:RESULTS:
+: 1
+*bold*
+*lbold*
+*mbold*
+: 2
+:END:
+"
+       :pandoc "t"))))
 
 ;; Local Variables:
 ;; byte-compile-warnings: (unresolved obsolete lexical)


### PR DESCRIPTION
Ensure correct output order when using Pandoc processes to convert code snippets to Org syntax. Fixes #351.