### PR TITLE
Update `dev`, remove `init` target in Makefile (no `--dev` option)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,15 +34,10 @@ zmq: cask
 	$(CASK) emacs -Q -batch --eval "(progn (fset 'read-string (lambda (&rest _) \"y\")) (require 'zmq))"
 endif
 
-.PHONY: init
-init: cask
-	$(CASK) install
-	$(CASK) update
-
 .PHONY: dev
 dev: cask
-	$(CASK) --dev install
-	$(CASK) --dev update
+	$(CASK) install
+	$(CASK) update
 
 .PHONY: test
 test: zmq


### PR DESCRIPTION
Since [this commit](https://github.com/cask/cask/commit/a8a2f72bef5e9a8ec62b6f1a0e52a8caf554570a), Cask doesn't provide `--dev` option anymore. Also, given that `dev` target looks like `init` now, I guess that the latter is not needed.