### PR TITLE
Make scratch buffers easier to identify

### DIFF
--- a/jupyter-comm-layer.el
+++ b/jupyter-comm-layer.el
@@ -112,9 +112,7 @@ called if needed.")
 
 (cl-defgeneric jupyter-comm-id ((comm jupyter-comm-layer))
   "Return an identification string for COMM.
-Can be used to identify this communication channel.  For example,
-used in `jupyter-repl-scratch-buffer' to name the scratch
-buffer.")
+Can be used to identify this communication channel.")
 
 (cl-defgeneric jupyter-event-handler (_obj _event)
   "Handle EVENT using OBJ."

--- a/jupyter-repl.el
+++ b/jupyter-repl.el
@@ -1653,8 +1653,9 @@ Return the buffer switched to."
   (interactive)
   (if (jupyter-repl-connected-p)
       (let* ((client jupyter-current-client)
-             (name (format "*jupyter-scratch[%s]*"
-                           (jupyter-comm-id (oref client kcomm)))))
+             (name (replace-regexp-in-string "^*jupyter-repl"
+					     "*jupyter-scratch"
+					     (buffer-name) (oref client buffer))))
         (unless (get-buffer name)
           (with-current-buffer (get-buffer-create name)
             (funcall (jupyter-kernel-language-mode client))


### PR DESCRIPTION
Having a couple of REPLs and scratch buffers opened, it's not easy to tell which scratch buffer belongs to which REPL, e.g.:

```
*jupyter-repl[kernel1]*
*jupyter-repl[kernel2]*-sess1
*jupyter-repl[kernel2]*-sess2
*jupyter-scratch[session=abe2f34b…]*
*jupyter-scratch[session=14695a88…]*
*jupyter-scratch[session=ad5c9748…]*
```

Let's say that I want to switch to a scratch buffer associated with `sess2` from some buffer other than its REPL. With the current naming scheme, it's not obvious which one is it. One may say: "but you can just switch to `sess2` REPL and then hit 'C-s' from there" - but this is a bit tedious, especially when someone wants to switch directly to some scratch buffer from the current window.

Therefore, I propose a small change which would render the previous example as follows:

```
*jupyter-repl[kernel1]*
*jupyter-repl[kernel2]*-sess1
*jupyter-repl[kernel2]*-sess2
*jupyter-scratch[kernel1]*
*jupyter-scratch[kernel2]*-sess1
*jupyter-scratch[kernel2]*-sess2
```

PS: I've noticed that `jupyter-comm-id` methods are not used anywhere, so maybe they can be removed?