### PR TITLE
Discard stderr from jupyter shell command

### DIFF
--- a/jupyter-env.el
+++ b/jupyter-env.el
@@ -47,7 +47,7 @@ The shell command run is
 If the command fails or the jupyter shell command doesn't exist,
 return nil."
   (with-temp-buffer
-    (when (zerop (apply #'process-file "jupyter" nil t nil args))
+    (when (zerop (apply #'process-file "jupyter" nil '(t nil) nil args))
       (string-trim-right (buffer-string)))))
 
 (defun jupyter-runtime-directory ()


### PR DESCRIPTION
In some situations, `jupyter kernelspec list --json` produces stderr warnings like

```
[ListKernelSpecs] WARNING | Native kernel (python3) is not available
```
which leads to a JSON parsing error

This change discards the stderr.