### PR TITLE
Sort available kernelspecs; guess with ^; use guessing in jupyter-run-repl

### DIFF
--- a/jupyter-repl.el
+++ b/jupyter-repl.el
@@ -2097,7 +2097,7 @@ completing all of the above.")
 ;;;###autoload
 (defun jupyter-run-repl (kernel-name &optional repl-name associate-buffer client-class display)
   "Run a Jupyter REPL connected to a kernel with name, KERNEL-NAME.
-KERNEL-NAME will be passed to `jupyter-find-kernelspecs' and the
+KERNEL-NAME will be passed to `jupyter-guess-kernelspec' and the
 first kernel found will be used to start the new kernel.
 
 With a prefix argument give a new REPL-NAME for the REPL.
@@ -2128,10 +2128,6 @@ command on the host."
                      t nil t))
   (or client-class (setq client-class 'jupyter-repl-client))
   (jupyter-error-if-not-client-class-p client-class 'jupyter-repl-client)
-  (unless (called-interactively-p 'interactive)
-    (or (when-let* ((name (caar (jupyter-find-kernelspecs kernel-name))))
-          (setq kernel-name name))
-        (error "No kernel found for prefix (%s)" kernel-name)))
   ;; For `jupyter-start-new-kernel', we don't require this at top-level since
   ;; there are many ways to interact with a kernel, e.g. through a notebook
   ;; server, and we don't want to load any unnecessary files.

--- a/test/jupyter-test.el
+++ b/test/jupyter-test.el
@@ -1912,6 +1912,24 @@ next(x"))))))
                     font-lock-extend-region-functions)))
         (font-lock-ensure)))))
 
+(ert-deftest jupyter-available-kernelspecs-sorting ()
+  :tags '(repl)
+  (jupyter-test-with-some-kernelspecs '("foo_qux" "qux" "bar_qux")
+    (let ((result (mapcar #'car (jupyter-available-kernelspecs t))))
+      (should (equal result (sort (copy-sequence result) #'string<))))))
+
+(ert-deftest jupyter-run-repl-issue-371 ()
+  :tags '(repl)
+  (jupyter-test-with-some-kernelspecs '("foo_qux" "qux" "bar_qux")
+    (let ((client))
+      (unwind-protect
+	  (progn
+	    (setq client (jupyter-run-repl "qux"))
+	    (should (equal (plist-get (jupyter-session-conn-info (oref client session))
+				      :kernel_name)
+			   "qux")))
+	(jupyter-test-kill-buffer (oref client buffer))))))
+
 ;;; `org-mode'
 
 (defvar org-babel-jupyter-resource-directory nil)


### PR DESCRIPTION
Fixes #371.

Turns out that there's no need to wrap `jupyter-run-repl`'s `KERNEL-NAME` in `^$`, as only `^` is needed when kernelspecs are sorted by names - and I think that this is actually closer to the original semantics, i.e. being able to specify just `python` instead of `python3` or `julia` instead of `julia-X.Y`.

With this approach, there's also no need for this extra call to `jupyter-find-kernelspecs` in `jupyter-run-repl` (and by extension, for this "fragile" check if `jupyter-run-repl` has been called interactively).

So, probably the most "controversial" change in this PR is "starting with `NAME`" instead of "matching `NAME`" in `jupyter-guess-kernelspec` - but I think that [the original idea for this fix](https://github.com/nnicandro/emacs-jupyter/issues/371#issuecomment-1038514708) was actually more "invasive" ;)