### PR TITLE
Fix available-kernelspecs failing from warning output

### DIFF
--- a/jupyter-kernelspec.el
+++ b/jupyter-kernelspec.el
@@ -61,7 +61,7 @@ each DIRECTORY will be a remote file name."
     (or (and (not refresh) (gethash host jupyter--kernelspecs))
         (let ((specs (plist-get
                       (jupyter-read-plist-from-string
-                       (or (jupyter-command "kernelspec" "list" "--json")
+                       (or (jupyter-command "kernelspec" "list" "--json" "--log-level" "ERROR")
                            (error "Can't obtain kernelspecs from jupyter shell command")))
                       :kernelspecs)))
           (puthash host


### PR DESCRIPTION
Would fix #301 

The PR limits the logs to `ERROR` so that the function (`jupyter-available-kernelspecs`) can still work if there is a warning. If `ERROR` or above is printed, probably it's a good idea for the function to fail?