### PR TITLE
Fix `(wrong-type-argument lisp ...)`

### DIFF
--- a/jupyter-server.el
+++ b/jupyter-server.el
@@ -309,8 +309,8 @@ is used as determined by `jupyter-current-server'."
 (defun jupyter-server-repl-interactive-spec ()
   (let ((server (jupyter-current-server current-prefix-arg)))
     (list server
-          (car (jupyter-completing-read-kernelspec
-                (jupyter-kernelspecs server)))
+          (jupyter-completing-read-kernelspec
+                (jupyter-kernelspecs server))
           ;; FIXME: Ambiguity with `jupyter-current-server' and
           ;; `current-prefix-arg'
           (when (and current-prefix-arg


### PR DESCRIPTION
I got the following error on Emacs 28.2, MacOS, and fixed it:

```
Debugger entered--Lisp error: (wrong-type-argument listp #s(jupyter-kernelspec :name "python3" :plist (:argv ["python" "-m" "ipykernel_launcher" "-f" "{connection_file}"] :env nil :display_name "Python 3 (ipykernel)" :language "python" :interrupt_mode "signal" :metadata (:debugger t)) :resource-directory nil))
```