### PR TITLE
correct spacing for example + image

### DIFF
--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -1530,7 +1530,8 @@ RESULT is the new result, as an org element, to be inserted.")
                           jupyter-org-strip-last-newline
                           jupyter-org-scalar)
                       result))))
-  (when (/= (point) (line-beginning-position))
+  (when (or (/= (point) (line-beginning-position))
+            (eq (org-element-type context) 'example-block))
     ;; Org objects such as file links do not have a newline added when
     ;; converting to their string representation by
     ;; `org-element-interpret-data' so insert one in these cases.


### PR DESCRIPTION
Do add an extra space when inserting an example block and an image.

Applies to situations like these:
![image](https://user-images.githubusercontent.com/4025991/161228666-0ae1e662-78f2-4e24-ba8a-0c6129edefdf.png)

Without this, inserting results will eat up lines.
